### PR TITLE
Upgrade to Node >=0.10 and assorted minor fixes

### DIFF
--- a/lib/x-recorder/xcapture.js
+++ b/lib/x-recorder/xcapture.js
@@ -60,9 +60,9 @@ Capture.prototype = {
         timeout;
 
     args = [
-      '-y', '-r', '30', '-g', '600',
+      '-y', '-r', '30', 
       '-s', this.dimensions, '-f', 'x11grab', '-i',
-      ':' + String(this.display), '-vcodec', this.codec,
+      ':' + String(this.display), '-g', '600', '-vcodec', this.codec,
       this.output
     ];
 

--- a/lib/x-recorder/xvfb.js
+++ b/lib/x-recorder/xvfb.js
@@ -166,7 +166,7 @@ Xvfb.prototype = {
     }
 
     path = fsPath.join(searchDir, this._getLockFile(display));
-    fsPath.exists(path, function(exists) {
+    fs.exists(path, function(exists) {
       if (exists) {
         if (typeof(once) !== 'undefined') {
           callback(new Error('There is a lock on display :' + display));

--- a/package.json
+++ b/package.json
@@ -4,29 +4,26 @@
   "author": "James Lal <james@lightsofapollo.com>",
   "description": "",
   "main": "lib/x-recorder/index.js",
-
   "repository": {
     "type": "git",
     "url": "https://github.com/.git"
   },
-
   "bin": {
     "x-recorder": "./bin/x-recorder"
   },
-
   "keywords": [
     "x11 record video screenshot screencast xvfb"
   ],
-  "dependencies" : {
+  "dependencies": {
     "optimist": "~0.3"
   },
   "devDependencies": {
-    "mocha": "1.1.0",
     "expect.js": "0.1.2",
-    "projstrap": "latest"
+    "mocha": "^2.0.1",
+    "tmp": "0.0.24"
   },
   "license": "MIT",
   "engine": {
-    "node": ">=0.4"
+    "node": ">=0.10"
   }
 }

--- a/scripts/start-video.js
+++ b/scripts/start-video.js
@@ -47,7 +47,7 @@ module.exports = new Script({
 
     lockFile = '/tmp/.X' + display + '-lock';
 
-    if (!fsPath.existsSync(lockFile)) {
+    if (!fs.existsSync(lockFile)) {
       console.error('There is no display running on :' + display);
       process.exit(1);
     }

--- a/scripts/stop-video.js
+++ b/scripts/stop-video.js
@@ -22,7 +22,7 @@ module.exports = new Script({
   var pidFile = argv.pid,
       pid;
 
-  if (!fsPath.existsSync(pidFile)) {
+  if (!fs.existsSync(pidFile)) {
     console.error(pidFile, 'was not found');
     process.exit(1);
   }

--- a/scripts/stop-xvfb.js
+++ b/scripts/stop-xvfb.js
@@ -23,7 +23,7 @@ module.exports = new Script({
 
   lockFile = '/tmp/.X' + display + '-lock';
 
-  if (fsPath.existsSync(lockFile)) {
+  if (fs.existsSync(lockFile)) {
     pid = fs.readFileSync(lockFile, 'utf8').trim();
     exec('kill ' + pid, function(err, stdout, stderr) {
       if (err) {


### PR DESCRIPTION
- Upgraded the code to work on >=0.10: fixed the 'path.existsSync' stuff
- Moved the '-g' option of ffmpeg to be an output option
- Use a proper temporary directory in tests

To be fair, there's nothing in here that stops you running with 0.6 upwards, but the whole self-signed cert stuff means that if you're using 0.6, you should really be upgrading anyway.
